### PR TITLE
Constraints from arbeitszeitgesetz

### DIFF
--- a/docs/Constraints.md
+++ b/docs/Constraints.md
@@ -65,8 +65,27 @@ Meaning early, late, night and not night, late, early. This maximizes the time t
 
 ### Not to long shifts (3.9)
 > Die Massierung von Arbeitstagen oder Arbeitszeiten auf einen Tag sollte begrenzt sein.
-
-Essentially that means that longs shifts (12h plus) should be restricted.
+Essentially that means that longs shifts (12h plus) should be restricted. But I think there are not 12h shift in our case.
 
 ### Weekend Rhythm (Kickoff Meeting)
 Some kind of regularity for the free weekends
+
+## Rest Time (2) (§5 (1,2))
+11 hours of rest time between shift. There is an exception for employees in the hospital: there it could only be 10 hours, if this is balanced during the current month by one rest time with 12 hours.
+For us it is easier to check if there are always two empty shifts between two working shifts. This is automatically the case for almost all cases, by restricting the employees to only have one shift per day. There are three cases where this "one-per-day" restriction does not cover the "Rest Time" Condition
+- Night to Early: Less than 11 hours, but covered by the "24h rest time after night shift"
+- Night to Late: Less than 11 hours, but covered by the "24h rest time after night shift"
+- Late to Early: Here we only have 9 hours of rest time. That is why we must not allow this combination
+
+## Rest Time On Call Duty (2) (§5 (3))
+On Call Duty is someone who is resting at that shift, but we mark him as "On Call Duty", which means he needs to work only if there is an emergency, and the lost rest time will be compensated later. So,
+1. We need another parameter - "lost rest time" for the worker, to calculate the rest time to be compensated.
+2. The working hours during the "On Call Duty" can't be longer than 5.5 hours, since the rest time for a hospital worker is a maximum of 11 hours.
+**Do we have "On Call Duty"?**
+
+## At least 15 Sundays free per year (2) (§11 (1))
+That is a compensation for the work on sundays and holidays
+
+## Replacement day when working on Sunday/Holiday (2) (§11 (2))
+- Work on Sunday: Free compensation day in the next two weeks
+- Work on a Holiday: Free compensation day in the next 8 weeks

--- a/docs/Constraints.md
+++ b/docs/Constraints.md
@@ -57,35 +57,41 @@ Free days should come in pairs (two) and include at least one weekend day:
 - Saturday and Sunday
 - Sunday and Monday
 
-### More free days for people with many night shifts (3.4)
-Not sure if this is applicable for our case
-
 ### Shifts should "rotate forward" (3.5)
 Meaning early, late, night and not night, late, early. This maximizes the time to rest between shifts.
-
-### Not to long shifts (3.9)
-> Die Massierung von Arbeitstagen oder Arbeitszeiten auf einen Tag sollte begrenzt sein.
-Essentially that means that longs shifts (12h plus) should be restricted. But I think there are not 12h shift in our case.
 
 ### Weekend Rhythm (Kickoff Meeting)
 Some kind of regularity for the free weekends
 
-## Rest Time (2) (§5 (1,2))
+### No Late to Early Shifts (from Rest Time (2) (§5 (1,2)))
+This is the essence of the "Rest Time Constraint" below adjusted to our case. 
+No Late to Early Shifts means that it is not allowed that an early shift follows a late shift, because then the rest time would not be long enough. 
+
+### At least 15 Sundays free per year (2) (§11 (1))
+That is a compensation for the work on sundays and holidays
+
+### Replacement day when working on Sunday/Holiday (2) (§11 (2))
+- Work on Sunday: Free compensation day in the next two weeks
+- Work on a Holiday: Free compensation day in the next 8 weeks
+
+## Constraints that might not apply in our case
+
+### More free days for people with many night shifts (3.4) (?)
+Not sure if this is applicable for our case
+
+### Rest Time (2) (§5 (1,2))
 11 hours of rest time between shift. There is an exception for employees in the hospital: there it could only be 10 hours, if this is balanced during the current month by one rest time with 12 hours.
 For us it is easier to check if there are always two empty shifts between two working shifts. This is automatically the case for almost all cases, by restricting the employees to only have one shift per day. There are three cases where this "one-per-day" restriction does not cover the "Rest Time" Condition
 - Night to Early: Less than 11 hours, but covered by the "24h rest time after night shift"
 - Night to Late: Less than 11 hours, but covered by the "24h rest time after night shift"
-- Late to Early: Here we only have 9 hours of rest time. That is why we must not allow this combination
+- Late to Early: Here we only have 9 hours of rest time. **That is why we must not allow this combination!**
 
-## Rest Time On Call Duty (2) (§5 (3))
+### Rest Time On Call Duty (2) (§5 (3)) (?)
 On Call Duty is someone who is resting at that shift, but we mark him as "On Call Duty", which means he needs to work only if there is an emergency, and the lost rest time will be compensated later. So,
 1. We need another parameter - "lost rest time" for the worker, to calculate the rest time to be compensated.
 2. The working hours during the "On Call Duty" can't be longer than 5.5 hours, since the rest time for a hospital worker is a maximum of 11 hours.
 **Do we have "On Call Duty"?**
 
-## At least 15 Sundays free per year (2) (§11 (1))
-That is a compensation for the work on sundays and holidays
-
-## Replacement day when working on Sunday/Holiday (2) (§11 (2))
-- Work on Sunday: Free compensation day in the next two weeks
-- Work on a Holiday: Free compensation day in the next 8 weeks
+### Not to long shifts (3.9) (?)
+> Die Massierung von Arbeitstagen oder Arbeitszeiten auf einen Tag sollte begrenzt sein.
+Essentially that means that longs shifts (12h plus) should be restricted. But I think there are not 12h shift in our case.

--- a/docs/Constraints.md
+++ b/docs/Constraints.md
@@ -64,8 +64,8 @@ Meaning early, late, night and not night, late, early. This maximizes the time t
 Some kind of regularity for the free weekends
 
 ### No Late to Early Shifts (from Rest Time (2) (§5 (1,2)))
-This is the essence of the "Rest Time Constraint" below adjusted to our case. 
-No Late to Early Shifts means that it is not allowed that an early shift follows a late shift, because then the rest time would not be long enough. 
+This is the essence of the "Rest Time Constraint" below adjusted to our case.
+No Late to Early Shifts means that it is not allowed that an early shift follows a late shift, because then the rest time would not be long enough.
 
 ### At least 15 Sundays free per year (2) (§11 (1))
 That is a compensation for the work on sundays and holidays


### PR DESCRIPTION
I have added the constraints we have talked about in #2. 
I have boiled "Rest Time" down to the "No Late to Early" constraint that essentially says that we do not allow an early shift after a late shift. 