### PR TITLE
Constraint free shifts and vacation

### DIFF
--- a/algorithm/building_constraints/free_shifts_and_vacation_days.py
+++ b/algorithm/building_constraints/free_shifts_and_vacation_days.py
@@ -26,16 +26,20 @@ def add_free_shifts_and_vacation_days(
         for employee in constraints["employees"]:
             employee_idx = name_to_index[employee["name"]]
             if "free_days" in employee:
-                for day in employee["free_days"]:
+                for day_int in employee[
+                    "free_days"
+                ]:  # day_int corresponds to real date, starts at 1
                     for s in range(num_shifts):
-                        model.Add(shifts[(employee_idx, day, s)] == 0)
+                        model.Add(
+                            shifts[(employee_idx, day_int - 1, s)] == 0
+                        )  # day_int to day_idx
                     model.Add(
-                        shifts[(employee_idx, day - 1, 2)] == 0
+                        shifts[(employee_idx, day_int - 2, 2)] == 0
                     )  # no night shift before vacation
             if "free_shifts" in employee:
-                for day, shift_name in employee["free_shifts"]:
+                for day_int, shift_name in employee["free_shifts"]:
                     shift_idx = shift_names_to_index[shift_name]
-                    model.Add(shifts[(employee_idx, day, shift_idx)] == 0)
+                    model.Add(shifts[(employee_idx, day_int - 1, shift_idx)] == 0)
     else:
         raise ValueError(
             "Dataformat `free shifts` does not fit. Key `employees` is missing."

--- a/algorithm/building_constraints/free_shifts_and_vacation_days.py
+++ b/algorithm/building_constraints/free_shifts_and_vacation_days.py
@@ -20,20 +20,25 @@ def add_free_shifts_and_vacation_days(
     Adds constraints for requested days off and shift exclusions.
     """
     name_to_index = {employee["name"]: idx for idx, employee in enumerate(employees)}
+    shift_names_to_index = {"F": 0, "S": 1, "N": 2}
 
-    if "time_off" in constraints:
-        for request in constraints["time_off"]:
-            employee_idx = name_to_index[request["name"]]
-            if "days_off" in request:
-                for day in request["days_off"]:
+    if "employees" in constraints:
+        for employee in constraints["employees"]:
+            employee_idx = name_to_index[employee["name"]]
+            if "free_days" in employee:
+                for day in employee["free_days"]:
                     for s in range(num_shifts):
                         model.Add(shifts[(employee_idx, day, s)] == 0)
                     model.Add(
-                        shifts[(employee_idx, day, 2)] == 0
+                        shifts[(employee_idx, day - 1, 2)] == 0
                     )  # no night shift before vacation
-
-            if "shifts_off" in request:
-                for shift in request["shifts_off"]:
-                    model.Add(shifts[(employee_idx, shift[0], shift[1])] == 0)
+            if "free_shifts" in employee:
+                for day, shift_name in employee["free_shifts"]:
+                    shift_idx = shift_names_to_index[shift_name]
+                    model.Add(shifts[(employee_idx, day, shift_idx)] == 0)
+    else:
+        raise ValueError(
+            "Dataformat `free shifts` does not fit. Key `employees` is missing."
+        )
 
     StateManager.state.constraints.append("Free Shifts and Vacation Days")

--- a/algorithm/building_constraints/initial_constraints.py
+++ b/algorithm/building_constraints/initial_constraints.py
@@ -52,11 +52,6 @@ def add_basic_constraints(
     all_shifts = range(num_shifts)
     all_days = range(num_days)
 
-    # one employee per (name, day, shift) tuple
-    for d in all_days:
-        for s in all_shifts:
-            model.add_exactly_one(shifts[(n, d, s)] for n in all_employees)
-
     # one shift per employee per day at most
     for n in all_employees:
         for d in all_days:

--- a/algorithm/building_constraints/initial_constraints.py
+++ b/algorithm/building_constraints/initial_constraints.py
@@ -2,6 +2,8 @@ import json
 import StateManager
 from ortools.sat.python import cp_model
 
+NAME_OF_CONSTRAINT = "Inital Constraints"
+
 
 def load_general_settings(filename):
     with open(filename, "r") as f:
@@ -41,7 +43,6 @@ def add_basic_constraints(
     """
     Adds fundamental scheduling constraints:
 
-    - Each shift on each day is assigned to exactly one employee.
     - Each employee can work at most one shift per day.
 
     These constraints form the structural foundation of the schedule.
@@ -54,7 +55,7 @@ def add_basic_constraints(
 
     # one shift per employee per day at most
     for n in all_employees:
-        for d in all_days:
-            model.add_at_most_one(shifts[(n, d, s)] for s in all_shifts)
+        for d_idx in all_days:
+            model.add_at_most_one(shifts[(n, d_idx, s)] for s in all_shifts)
 
-    StateManager.state.constraints.append("Initial")
+    StateManager.state.constraints.append(NAME_OF_CONSTRAINT)

--- a/algorithm/building_constraints/target_working_hours.py
+++ b/algorithm/building_constraints/target_working_hours.py
@@ -1,6 +1,8 @@
 import json
 import StateManager
 
+NAME_OF_CONSTRAINT = "Target Working Hours"
+
 
 def load_target_working_hours(filename, settings_filename):
     with open(filename, "r") as f:
@@ -54,9 +56,9 @@ def add_target_working_hours(
 
     for n in all_employees:
         work_time_terms = []
-        for d in all_days:
+        for d_idx in all_days:
             for s in all_shifts:
-                var = shifts[(n, d, s)]  # this is a BoolVar (0 or 1)
+                var = shifts[(n, d_idx, s)]  # this is a BoolVar (0 or 1)
                 duration = shift_durations[s]  # duration in hours for shift s
                 work_time_terms.append(var * duration)
 
@@ -69,4 +71,4 @@ def add_target_working_hours(
         model.Add(total_work_time == sum(work_time_terms))
         model.Add(total_work_time <= target_hours + tolerance_hours)
 
-    StateManager.state.constraints.append("Target Working Hours")
+    StateManager.state.constraints.append(NAME_OF_CONSTRAINT)

--- a/cases/1/free_shifts_and_vacation_days.json
+++ b/cases/1/free_shifts_and_vacation_days.json
@@ -1,22 +1,52 @@
 {
-  "time_off": [
+  "employees": [
     {
-      "days_off": [
-        1
+      "firstname": "",
+      "free_days": [
+        2,
+        12
       ],
-      "name": "Pauline",
-      "shifts_off": [
+      "free_shifts": [
+        [
+          3,
+          "F"
+        ],
         [
           4,
-          2
+          "N"
         ]
-      ]
+      ],
+      "name": "Pauline"
     },
     {
-      "days_off": [
-        2
+      "firstname": "",
+      "free_days": [
+        22,
+        23,
+        24
+      ],
+      "free_shifts": [
+        [
+          1,
+          "F"
+        ],
+        [
+          2,
+          "F"
+        ]
       ],
       "name": "Marie"
+    },
+    {
+      "firstname": "",
+      "free_days": [],
+      "free_shifts": [
+        [
+          19,
+          "N"
+        ]
+      ],
+      "name": "Dumbledore"
     }
   ]
 }

--- a/docs/ConstraintDataFormat.md
+++ b/docs/ConstraintDataFormat.md
@@ -1,0 +1,82 @@
+# Data format of each constraint
+Most of the constraint need some kind of input. This input is save in `cases/i/`
+and stored as `json` file.
+The person who implements a new constraint does decide how the constraint
+is formulated / what the data format should look like, but is also
+responseable for its documentation.
+
+## Minimal Number of Staff
+For each type of staff there is a dictornary with each day of the week, providing the required number of staff per shift. The shift keys are `"F"`, `"S"` and `"N"`, for the german terms "Frühschicht","Spätschicht", "Nachtschicht".
+The weekdays are also in german and abbreviated.
+**Example:**
+```json
+{
+  "Fachkraft": {
+    "Mo": {"F": 1, "S": 1, "N": 1},
+    "Di": {"F": 1, "S": 4, "N": 3},
+    "Mi": {"F": 3, "S": 3, "N": 1},
+    "Do": {"F": 2, "S": 1, "N": 1},
+    "Fr": {"F": 1, "S": 2, "N": 1},
+    "Sa": {"F": 2, "S": 1, "N": 3} ,
+    "So": {"F": 1, "S": 2, "N": 1}
+  },
+  "Hilfskraft" : {
+    "Mo": {"F": 1, "S": 1, "N": 1},
+    "Di": {"F": 1, "S": 1, "N": 1},
+    "Mi": {"F": 1, "S": 1, "N": 1},
+    "Do": {"F": 1, "S": 1, "N": 1},
+    "Fr": {"F": 1, "S": 1, "N": 1},
+    "Sa": {"F": 1, "S": 1, "N": 1} ,
+    "So": {"F": 1, "S": 1, "N": 1}
+  },
+  "Azubi" : {
+    "Mo": {"F": 1, "S": 1, "N": 1},
+    "Di": {"F": 1, "S": 1, "N": 1},
+    "Mi": {"F": 1, "S": 1, "N": 1},
+    "Do": {"F": 1, "S": 1, "N": 1},
+    "Fr": {"F": 1, "S": 1, "N": 1},
+    "Sa": {"F": 1, "S": 1, "N": 1} ,
+    "So": {"F": 1, "S": 1, "N": 1}
+  }
+}
+```
+
+## Free Shifts and Vacation Days
+All employees that have requested free shifts or vacation days a listed here with
+first and lastname. The example leaves our firstname because in the toy data
+they only have one string as name.
+The free days are given by a list of integers. Each interger corresponds to the day
+of the month, e.g. `[1,3]` means 1. and 3. free.
+The shift keys are `"F"`, `"S"` and `"N"`, for the german terms "Frühschicht", "Spätschicht","Nachtschicht".
+```json
+{
+    "employees": [
+      {
+        "name": "Pauline",
+        "firstname": "",
+        "free_days": [2,12],
+        "free_shifts": [
+            [3, "F"],
+            [4, "N"]
+        ]
+      },
+      {
+        "name": "Marie",
+        "firstname": "",
+        "free_days": [22, 23, 24],
+        "free_shifts": [
+            [1, "F"],
+            [2, "S"]
+        ]
+      },
+      {
+        "name": "Dumbledore",
+        "firstname": "",
+        "free_days": [],
+        "free_shifts": [
+            [19, "N"]
+        ]
+      }
+    ]
+  }
+```


### PR DESCRIPTION
Related to #31 

Free shifts and vacation days was part of the initial structure but the data format was done poorly. 
Now we have the free shifts and days grouped by the employee (with first and last name). 

@philipplentzen I have added an issue about the Json pretty format, because it makes the config files much less human readable #43 

This branch does handle the day index as starting from 1, not zero. 