### PR TITLE
Fixed shift workers

### DIFF
--- a/algorithm/building_constraints/free_shifts_and_vacation_days.py
+++ b/algorithm/building_constraints/free_shifts_and_vacation_days.py
@@ -1,14 +1,7 @@
-import json
 import StateManager
 from ortools.sat.python import cp_model
 
 NAME_OF_CONSTRAINT = "free shifts and vacation days"
-
-
-def load_free_shifts_and_vacation_days(filename):
-    with open(filename, "r") as f:
-        data = json.load(f)
-    return data
 
 
 def add_free_shifts_and_vacation_days(
@@ -35,10 +28,11 @@ def add_free_shifts_and_vacation_days(
                         model.Add(
                             shifts[(employee_idx, day_int - 1, s)] == 0
                         )  # day_int to day_idx
-                    model.Add(
-                        shifts[(employee_idx, day_int - 2, 2)] == 0
-                    )  # no night shift before vacation
-            if "free_shifts" in employee:
+                    if day_int >= 2:  # prevent index of -1
+                        model.Add(
+                            shifts[(employee_idx, day_int - 2, 2)] == 0
+                        )  # no night shift before vacation
+            if "free_shifts" in employee and len(employee["free_shifts"][0]) > 0:
                 for day_int, shift_name in employee["free_shifts"]:
                     shift_idx = shift_names_to_index[shift_name]
                     model.Add(shifts[(employee_idx, day_int - 1, shift_idx)] == 0)

--- a/algorithm/building_constraints/initial_constraints.py
+++ b/algorithm/building_constraints/initial_constraints.py
@@ -1,20 +1,7 @@
-import json
 import StateManager
 from ortools.sat.python import cp_model
 
 NAME_OF_CONSTRAINT = "Inital Constraints"
-
-
-def load_general_settings(filename):
-    with open(filename, "r") as f:
-        config = json.load(f)
-    return config
-
-
-def load_employees(filename):
-    with open(filename, "r") as f:
-        data = json.load(f)
-    return data["employees"]
 
 
 def create_shift_variables(

--- a/algorithm/building_constraints/minimal_number_of_staff.py
+++ b/algorithm/building_constraints/minimal_number_of_staff.py
@@ -1,12 +1,6 @@
-import json
 import StateManager
 
 NAME_OF_CONSTRAINT = "Minimal Number of Staff"
-
-
-def load_min_number_of_staff(filename):
-    with open(filename, "r") as f:
-        return json.load(f)
 
 
 def add_min_number_of_staff(
@@ -14,6 +8,7 @@ def add_min_number_of_staff(
     employees,
     shifts,
     requirements,
+    employee_types,
     first_weekday_idx_of_month,
     last_day_of_month,
 ):
@@ -30,7 +25,12 @@ def add_min_number_of_staff(
         )
         current_weekday = weekday_mapping[current_weekday_index]
         for staff_type in requirements.keys():
-            relevant_employees = employee_idx_by_type[staff_type]
+            staff_groups = employee_types[staff_type]
+            relevant_employees = [
+                employee_id
+                for staff_group in staff_groups
+                for employee_id in employee_idx_by_type[staff_group]
+            ]
             for shift in requirements[staff_type][current_weekday].keys():
                 shift_index = shift_mapping.index(shift)
                 required_count = requirements[staff_type][current_weekday][shift]

--- a/cases/2/employee_types.json
+++ b/cases/2/employee_types.json
@@ -1,0 +1,20 @@
+{
+  "Azubi": [
+    "Bundesfreiwilligendienst (BFD)",
+    "Krankenpflegehelfer/in (1 j\u00e4hrige A.) (81301-006)"
+  ],
+  "Fachkraft": [
+    "Altenpfleger/in (82102-002)",
+    "A-Pflegefachkraft (Krankenpflege) (A-81302-018)",
+    "Pflegefachkraft (Krankenpflege) (81302-018)",
+    "Krankenschwester/-pfleger (81302-008)",
+    "Gesundheits- und Krankenpfleger/in (81302-005)",
+    "Pflegefachkraft (Krankenpflege) (81302-018)",
+    "Medizinische/r Fachangestellte/r (81102-004)"
+  ],
+  "Hilfskraft": [
+    "Helfer/in - station\u00e4re Krankenpflege (81301-002)",
+    "A-Pflegeassistent/in (A-81302-014)",
+    "Stationshilfe (81301-018)"
+  ]
+}


### PR DESCRIPTION
- Added a mapping for employee types
- Fixed some issues with the conversion from integer representation of days to index representation
- Constraints for fixed shifts are included in free_shifts_and_vacation_days.json
- Switched default case to case 2
- Removed redundant json import functions and moved it to a single generic load_json helper function

Code runs now but does not find a solution. I'm also unsure whether the mapping of the employee types to the three categories "Azubi", "Fachkraft" and "Hilfskraft" is correct.

Closes #55 
