### PR TITLE
Update the routing for docs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # Welcome to Staff Scheduling Documentations
 
-We are happy to have you here! You can find answers to all your questions within this documentation, which is loosely divided into two distinct views: the [**User View**](/user-view) and the [**Developer View**](/developer-view).
+We are happy to have you here! You can find answers to all your questions within this documentation, which is loosely divided into two distinct views: the [**User View**](StaffScheduling/user-view) and the [**Developer View**](/developer-view).
 
-If you are primarily interested in using and testing the Automatic Staff Scheduling system, you'll find all the important information in the [User View](/user-view) without delving too deeply into technical details. On the other hand, if you wish to contribute to or further develop this project, be sure to check out the [Developer View](/developer-view).
+If you are primarily interested in using and testing the Automatic Staff Scheduling system, you'll find all the important information in the [User View](StaffScheduling/user-view) without delving too deeply into technical details. On the other hand, if you wish to contribute to or further develop this project, be sure to check out the [Developer View](StaffScheduling/developer-view).
 
 Please note that as a user, you can always dive deeper into the technical details, and as a developer, you are welcome to revisit the general concepts whenever needed.
 
@@ -10,13 +10,13 @@ Please note that as a user, you can always dive deeper into the technical detail
 If you want to try out the automatic creation of the a staff schedule yourself, follow our
 "Getting Started Guides":
 
-- [User View - Getting Started Guide](/user-view/getting-started)
-- [Developer View - Getting Started Guide](/developer-view/getting-started)
+- [User View - Getting Started Guide](StaffScheduling/user-view/getting-started)
+- [Developer View - Getting Started Guide](StaffScheduling/developer-view/getting-started)
 
 ## Getting an Overview
 If you just want to get an overview over the codebase and the problem,
 you should start with those guides:
 
-- [Problem Defintion](/user-view/problem-definition)
-- [Mathematical Problem Formulation](developer-view/mathematical-problem-formulation)
-- [Codebase Overview](/developer-view/codebase-overview)
+- [Problem Defintion](StaffScheduling/user-view/problem-definition)
+- [Mathematical Problem Formulation](StaffScheduling/developer-view/mathematical-problem-formulation)
+- [Codebase Overview](StaffScheduling/developer-view/codebase-overview)


### PR DESCRIPTION
There are still problem when clicking the link on combirwth, the link will lead to the page with 404 error, that's because the link to each doc should be for example StaffScheduling/user-view/... instead of user-view/...