### PR TITLE
Conservative approach: Use SUM because:

### DIFF
--- a/src/loader/loader.py
+++ b/src/loader/loader.py
@@ -20,8 +20,9 @@ class Loader(ABC):
         Retrieves a list of employees.
         """
         min_staffing = self.get_min_staffing()
+
         num_hidden_employees_per_level = {
-            level: max(max(shifts.values()) for shifts in days.values()) for level, days in min_staffing.items()
+            level: max(sum(shifts.values()) for shifts in days.values()) for level, days in min_staffing.items()
         }
 
         hidden_employees: list[Employee] = []


### PR DESCRIPTION
1. In practice, hospitals often need staff from multiple shifts simultaneously
2. Min staffing JSON specifies requirements PER SHIFT (not per time period)
3. If Sa: {F:2, S:2, N:1}, we interpret this as needing these staff ON those shifts (even if shifts don't fully overlap, staff are assigned to specific shifts)